### PR TITLE
Atualiza textos de advertência para avisos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@
  <li>Cadastro e gerenciamento das informações de alunos; </li>
  <li>Cadastro e gerenciamento de disciplinas com a opção de associar alunos a alguma disciplina; </li>
  <li>Gerenciamento de notas dos alunos;</li>
- <li>Cadastro/Gerenciamento de advertências;</li>
+ <li>Cadastro/Gerenciamento de avisos;</li>
  <li>Gerenciamento de faltas (ainda em desenvolvimento...);</li>
  <br>
  <h5>Com a permissão de aluno: </h5>
  <li>Login;</li>
  <li>Visualização de notas nas disciplinas; </li>
- <li>Visualização de advertências;</li>
+ <li>Visualização de avisos;</li>
  <li>Visualização de faltas (ainda em desenvolvimento...);</li>
  <br>
  

--- a/frontend/src/screens/Student/StudentHomeScreen/index.tsx
+++ b/frontend/src/screens/Student/StudentHomeScreen/index.tsx
@@ -20,8 +20,8 @@ export function StudentHomeScreen() {
     },
     {
       image: warningImage,
-      alt: 'Botão de dvertências',
-      title: 'Advertências',
+      alt: 'Botão de avisos',
+      title: 'Avisos',
       onClickCallback: () => {
         router.push('/student/warnings')
       },

--- a/frontend/src/screens/Student/Warnnings/index.tsx
+++ b/frontend/src/screens/Student/Warnnings/index.tsx
@@ -30,7 +30,7 @@ export function Warnings() {
         setWarnings(res.data.items)
       })
       .catch((err) => {
-        console.log('ERRO AO BUSCAR ADVERTÊNCIAS, ', err)
+        console.log('ERRO AO BUSCAR AVISOS, ', err)
       })
       .finally(() => {
         setLoadingWarnings(false)
@@ -48,14 +48,14 @@ export function Warnings() {
           loading={loadingWarnings}
           columns={columns}
           rows={warnings}
-          emptyText="Você não possui advertências"
+          emptyText="Você não possui avisos"
         />
       </div>
       <div className={style.viewMobile}>
         <ListMobile
           collapseItems={columns}
           items={warnings}
-          emptyText="Você não possui advertências"
+          emptyText="Você não possui avisos"
           loading={loadingWarnings}
           itemFields={fieldsMobile}
         />

--- a/frontend/src/screens/Teacher/StudentsAbsences/ModalWarnings/index.tsx
+++ b/frontend/src/screens/Teacher/StudentsAbsences/ModalWarnings/index.tsx
@@ -68,7 +68,7 @@ export function ModalWarnings({
           ...alertNotifyConfigs,
           open: true,
           type: 'success',
-          text: 'Advertências cadastrada com sucesso',
+          text: 'Aviso cadastrado com sucesso',
         })
         getWarnings()
         setIsFormMode(false)
@@ -80,7 +80,7 @@ export function ModalWarnings({
           open: true,
           type: 'success',
           text:
-            'Advertências cadastrada com sucesso, ' + err.response.data.message,
+            'Aviso cadastrado com sucesso, ' + err.response.data.message,
         })
       })
       .finally(() => {
@@ -96,7 +96,7 @@ export function ModalWarnings({
         setWarnings(res.data.items)
       })
       .catch((err) => {
-        console.log('ERRO AO BUSCAR ADVERTÊNCIAS')
+        console.log('ERRO AO BUSCAR AVISOS')
         console.log(err?.response?.data?.message)
       })
       .finally(() => {
@@ -117,7 +117,7 @@ export function ModalWarnings({
       open={open}
       handleClose={handleClose}
       onSubmit={isFormMode ? onCreateNewWarning : undefined}
-      title="Advertências"
+      title="Avisos"
       submitButtonText={isFormMode ? 'Confirmar' : ''}
       loading={loadingCreateWarning}
     >
@@ -130,8 +130,8 @@ export function ModalWarnings({
               setIsFormMode(true)
             }}
           >
-            <FontAwesomeIcon className={style.icon} icon={faPlus} />
-            Nova advertência
+          <FontAwesomeIcon className={style.icon} icon={faPlus} />
+          Novo aviso
           </button>
         )}
 
@@ -150,7 +150,7 @@ export function ModalWarnings({
         {warnings?.length === 0 && !loadingWarnings && (
           <EmptyItems
             customStyle={{ boxShadow: 'none' }}
-            text="Este aluno não possui advertências"
+            text="Este aluno não possui avisos"
           />
         )}
 

--- a/frontend/src/screens/Teacher/StudentsAbsences/hooks/useColumns.tsx
+++ b/frontend/src/screens/Teacher/StudentsAbsences/hooks/useColumns.tsx
@@ -18,7 +18,7 @@ export function useColumns({ handleOpenWarnings }: UseColumnsParams) {
       valueFormatter: (params: CellFunctionParams<any>) => params.value || '--',
     },
     {
-      headerName: 'Quantidade de advertências',
+      headerName: 'Quantidade de avisos',
       field: 'warningsAmount',
       valueFormatter: (params: CellFunctionParams<any>) => params?.value || 0,
     },

--- a/frontend/src/screens/Teacher/StudentsWarnings/ModalWarnings/index.tsx
+++ b/frontend/src/screens/Teacher/StudentsWarnings/ModalWarnings/index.tsx
@@ -64,7 +64,7 @@ export function ModalWarnings({
           ...alertNotifyConfigs,
           open: true,
           type: 'success',
-          text: 'Advertências cadastrada com sucesso',
+          text: 'Aviso cadastrado com sucesso',
         })
         getWarnings()
         getStudents()
@@ -77,7 +77,7 @@ export function ModalWarnings({
           open: true,
           type: 'success',
           text:
-            'Advertências cadastrada com sucesso, ' + err.response.data.message,
+            'Aviso cadastrado com sucesso, ' + err.response.data.message,
         })
       })
       .finally(() => {
@@ -93,7 +93,7 @@ export function ModalWarnings({
         setWarnings(res.data.items)
       })
       .catch((err) => {
-        console.log('ERRO AO BUSCAR ADVERTÊNCIAS')
+        console.log('ERRO AO BUSCAR AVISOS')
         console.log(err?.response?.data?.message)
       })
       .finally(() => {
@@ -113,7 +113,7 @@ export function ModalWarnings({
       open={open}
       handleClose={handleClose}
       onSubmit={isFormMode ? onCreateNewWarning : undefined}
-      title="Advertências"
+      title="Avisos"
       submitButtonText={isFormMode ? 'Confirmar' : ''}
       loading={loadingCreateWarning}
     >
@@ -126,7 +126,7 @@ export function ModalWarnings({
           }}
         >
           <FontAwesomeIcon className={style.icon} icon={faPlus} />
-          Nova advertência
+          Novo aviso
         </button>
       )}
 
@@ -143,7 +143,7 @@ export function ModalWarnings({
       {!isFormMode && (
         <ListMobile
           items={warnings}
-          emptyText="Nenhuma advertência encontrada"
+          emptyText="Nenhum aviso encontrado"
           itemFields={fieldsMobile}
           collapseItems={collapseItems}
           loading={loadingWarnings}

--- a/frontend/src/screens/Teacher/StudentsWarnings/StudentsWarnings.module.scss
+++ b/frontend/src/screens/Teacher/StudentsWarnings/StudentsWarnings.module.scss
@@ -70,7 +70,7 @@
         color: $white-color;
 
         &::after {
-          content: "Advertências";
+          content: "Avisos";
         }
       }
     }

--- a/frontend/src/screens/Teacher/StudentsWarnings/hooks/useColumns.tsx
+++ b/frontend/src/screens/Teacher/StudentsWarnings/hooks/useColumns.tsx
@@ -23,7 +23,7 @@ export function useColumns({ handleOpenWarnings }: UseColumnsParams) {
         params?.value || '--',
     },
     {
-      headerName: 'Advertências',
+      headerName: 'Avisos',
       field: 'warningsAmount',
       valueFormatter: (params: CellFunctionParams<Student>) =>
         params?.value || 0,

--- a/frontend/src/screens/Teacher/TeacherHomeScreen/index.tsx
+++ b/frontend/src/screens/Teacher/TeacherHomeScreen/index.tsx
@@ -29,8 +29,8 @@ export function TeacherHomeScreen() {
     },
     {
       image: warningImage,
-      alt: 'Botão de dvertências',
-      title: 'Advertências',
+      alt: 'Botão de avisos',
+      title: 'Avisos',
 
       onClickCallback: () => {
         router.push('/teacher/studentsWarnings')


### PR DESCRIPTION
## Summary
- rename textual references from "Advertências" to "Avisos" across teacher and student components
- adjust button labels and placeholder messages
- update README to reflect the new wording

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in both `frontend` and `backend` *(fail: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686562de54288322b6ee745d04fa014a