### PR TITLE
Fix auto logout when token invalid

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -21,4 +21,18 @@ http.interceptors.request.use(
   },
 )
 
+http.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status
+    if (status === 401 || status === 403) {
+      tokenService.deleteToken()
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login'
+      }
+    }
+    return Promise.reject(error)
+  },
+)
+
 export default http


### PR DESCRIPTION
## Summary
- add axios response interceptor to logout and redirect when auth token is invalid

## Testing
- `npm run lint` (fails: ESLint couldn't find config)
- `npm run test` in backend (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_e_68659f93f6b88322b46c7d1391f4d662