### PR TITLE
Implement subject warnings

### DIFF
--- a/backend/src/controllers/WarningController.ts
+++ b/backend/src/controllers/WarningController.ts
@@ -2,6 +2,7 @@ import { ListWarningsService } from '../useCases/Warning/ListWarnings/ListWarnin
 import { Request, Response } from 'express'
 import { container } from 'tsyringe'
 import { CreateNewWarningService } from '../useCases/Warning/CreateNewWarning/CreateNewWarningService.service'
+import { CreateWarningsBySubjectService } from '../useCases/Warning/CreateWarningsBySubject/CreateWarningsBySubjectService.service'
 
 export class WarningController {
   async createNewWarning(req: Request, res: Response): Promise<Response> {
@@ -18,6 +19,23 @@ export class WarningController {
     return res.status(201).json({
       item: warning,
       message: 'Advertência cadastrada com sucesso.',
+    })
+  }
+
+  async createWarningsBySubject(req: Request, res: Response): Promise<Response> {
+    const { idSubject } = req.params
+    const { title, description } = req.body
+
+    const createWarningsBySubjectService = container.resolve(CreateWarningsBySubjectService)
+    const warnings = await createWarningsBySubjectService.execute({
+      idSubject,
+      title,
+      description,
+    })
+
+    return res.status(201).json({
+      items: warnings,
+      message: 'Avisos cadastrados com sucesso.',
     })
   }
 

--- a/backend/src/shared/infra/http/routes/warnings.ts
+++ b/backend/src/shared/infra/http/routes/warnings.ts
@@ -8,6 +8,7 @@ const warningController = new WarningController()
 warningsRoutes.use(ensureAuthenticated)
 
 warningsRoutes.post('/:idStudent', warningController.createNewWarning)
+warningsRoutes.post('/subject/:idSubject', warningController.createWarningsBySubject)
 
 warningsRoutes.get('/:idStudent', warningController.listWarnings)
 

--- a/backend/src/useCases/Warning/CreateWarningsBySubject/CreateWarningsBySubject.spec.ts
+++ b/backend/src/useCases/Warning/CreateWarningsBySubject/CreateWarningsBySubject.spec.ts
@@ -1,0 +1,63 @@
+import { Types } from 'mongoose'
+import { MockWarningsRepository } from '../../../repositories/Warnings/MockWarningsRepository'
+import { MockUsersRepository } from '../../../repositories/Users/MockUsersRepository'
+import { MockSubjectsRepository } from '../../../repositories/Subjects/MockSubjectsRepository'
+import { CreateWarningsBySubjectService } from './CreateWarningsBySubjectService.service'
+import { CreateStudentService } from '../../Student/CreateStudent/CreateStudentService.service'
+import { CreateNewSubjectService } from '../../Subject/CreateNewSubject/CreateNewSubjectService.service'
+
+let mockWarningsRepository: MockWarningsRepository
+let mockUsersRepository: MockUsersRepository
+let mockSubjectsRepository: MockSubjectsRepository
+let createWarningsBySubjectService: CreateWarningsBySubjectService
+let createStudentService: CreateStudentService
+let createSubjectService: CreateNewSubjectService
+
+describe('Create warnings by subject', () => {
+  beforeEach(() => {
+    mockWarningsRepository = new MockWarningsRepository()
+    mockUsersRepository = new MockUsersRepository()
+    mockSubjectsRepository = new MockSubjectsRepository()
+    createWarningsBySubjectService = new CreateWarningsBySubjectService(
+      mockWarningsRepository,
+      mockSubjectsRepository,
+      mockUsersRepository,
+    ) as any
+    createStudentService = new CreateStudentService(mockUsersRepository)
+    createSubjectService = new CreateNewSubjectService(mockSubjectsRepository)
+  })
+
+  it('should create warnings for all students in subject', async () => {
+    const teacherId = new Types.ObjectId().toString()
+    const student1 = await createStudentService.execute({
+      name: 'John',
+      email: 'john@example.com',
+      password: '1234',
+      idTeacher: teacherId,
+    })
+    const student2 = await createStudentService.execute({
+      name: 'Jane',
+      email: 'jane@example.com',
+      password: '1234',
+      idTeacher: teacherId,
+    })
+
+    const subject = await createSubjectService.execute({
+      name: 'Math',
+      idTeacher: teacherId,
+    })
+
+    await mockSubjectsRepository.insertStudent({
+      subjectId: subject._id.toString(),
+      studentsIds: [student1._id.toString(), student2._id.toString()],
+    })
+
+    const warnings = await createWarningsBySubjectService.execute({
+      idSubject: subject._id.toString(),
+      title: 'Aviso',
+      description: 'Prova amanhã',
+    })
+
+    expect(warnings).toHaveLength(2)
+  })
+})

--- a/backend/src/useCases/Warning/CreateWarningsBySubject/CreateWarningsBySubjectService.service.ts
+++ b/backend/src/useCases/Warning/CreateWarningsBySubject/CreateWarningsBySubjectService.service.ts
@@ -1,0 +1,54 @@
+import { inject, injectable } from 'tsyringe'
+import { AppError } from '../../../shared/errors/AppError'
+import { ISubjectsRepository } from '../../../repositories/Subjects/ISubjectsRepository'
+import { IWarningsRepository } from '../../../repositories/Warnings/IWarningsRepository'
+import { IUsersRepository } from '../../../repositories/Users/IUsersRepository'
+import { Warning } from '../../../entities/warning'
+
+interface IRequest {
+  idSubject: string
+  title: string
+  description: string
+}
+
+@injectable()
+export class CreateWarningsBySubjectService {
+  warningsRepository: IWarningsRepository
+  subjectsRepository: ISubjectsRepository
+  usersRepository: IUsersRepository
+  constructor(
+    @inject('WarningsRepository') warningsRepository: IWarningsRepository,
+    @inject('SubjectsRepository') subjectsRepository: ISubjectsRepository,
+    @inject('UsersRepository') usersRepository: IUsersRepository,
+  ) {
+    this.warningsRepository = warningsRepository
+    this.subjectsRepository = subjectsRepository
+    this.usersRepository = usersRepository
+  }
+
+  async execute({ idSubject, title, description }: IRequest): Promise<Warning[]> {
+    if (!idSubject) throw new AppError('_id da disciplina não foi informado')
+    if (!title) throw new AppError('Título não foi informado')
+
+    const subject = await this.subjectsRepository.findById(idSubject)
+    if (!subject) throw new AppError('Disciplina não encontrada')
+
+    const warnings: Warning[] = []
+    const studentsIds = subject.students as any[]
+
+    for (const idStudent of studentsIds) {
+      const entries = await this.warningsRepository.getEntries(idStudent.toString())
+      const code = (entries + 1).toString()
+      const warning = await this.warningsRepository.create({
+        idStudent: idStudent.toString(),
+        title,
+        description,
+        code,
+      })
+      await this.usersRepository.incrementWarningsAmount(idStudent.toString())
+      warnings.push(warning)
+    }
+
+    return warnings
+  }
+}

--- a/frontend/src/services/warningsService.ts
+++ b/frontend/src/services/warningsService.ts
@@ -17,6 +17,11 @@ export const warningsService = {
     })
   },
 
+  createBySubject(idSubject: string, newWarningData: NewWarning) {
+    const body = { ...newWarningData }
+    return http.post(`/warnings/subject/${idSubject}`, { ...body })
+  },
+
   getAll(idStudent: string) {
     return http.get('/warnings/' + idStudent)
   },


### PR DESCRIPTION
## Summary
- add service to create warnings for all students within a subject
- expose controller and route for new subject-based warnings
- extend warningsService on the frontend with `createBySubject`
- add unit tests for new service

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a33164b48322b77c46e6fa4bc162