### PR TITLE
Adjust teacher absence features

### DIFF
--- a/backend/src/controllers/ClassLessonController.ts
+++ b/backend/src/controllers/ClassLessonController.ts
@@ -3,13 +3,14 @@ import { container } from 'tsyringe'
 import { CreateClassLessonService } from '../useCases/ClassLesson/CreateClassLesson/CreateClassLessonService.service'
 import { ListClassLessonsService } from '../useCases/ClassLesson/ListClassLessons/ListClassLessonsService.service'
 import { UpdateClassLessonService } from '../useCases/ClassLesson/UpdateClassLesson/UpdateClassLessonService.service'
+import { DeleteClassLessonService } from '../useCases/ClassLesson/DeleteClassLesson/DeleteClassLessonService.service'
 
 export class ClassLessonController {
   async create(req: Request, res: Response): Promise<Response> {
-    const { subjectId, date, teacherPassword } = req.body
+    const { subjectId, description } = req.body
     const { _id: teacherId } = req.user
     const service = container.resolve(CreateClassLessonService)
-    await service.execute({ subjectId, date, teacherId, teacherPassword })
+    await service.execute({ subjectId, teacherId, description })
     return res.status(201).json({ success: true })
   }
 
@@ -24,6 +25,13 @@ export class ClassLessonController {
     const { date, description } = req.body
     const service = container.resolve(UpdateClassLessonService)
     await service.execute({ id, date, description })
+    return res.status(200).json({ success: true })
+  }
+
+  async delete(req: Request, res: Response): Promise<Response> {
+    const { id } = req.params
+    const service = container.resolve(DeleteClassLessonService)
+    await service.execute(id)
     return res.status(200).json({ success: true })
   }
 }

--- a/backend/src/repositories/ClassLessons/ClassLessonsRepository.ts
+++ b/backend/src/repositories/ClassLessons/ClassLessonsRepository.ts
@@ -8,10 +8,11 @@ export class ClassLessonsRepository implements IClassLessonsRepository {
     this.model = ClassLessonModel
   }
 
-  async create({ subjectId, date }: INewClassLessonDTO): Promise<ClassLesson> {
+  async create({ subjectId, date, description }: INewClassLessonDTO): Promise<ClassLesson> {
     const newLesson = await this.model.create({
       subject: subjectId,
       date,
+      description,
     })
     await newLesson.save()
     return newLesson
@@ -21,11 +22,12 @@ export class ClassLessonsRepository implements IClassLessonsRepository {
     return await this.model.find().populate('subject').sort({ date: 1 })
   }
 
-  async update(
-    id: string,
-    data: Partial<INewClassLessonDTO & { description?: string }>,
-  ): Promise<void> {
+  async update(id: string, data: Partial<INewClassLessonDTO>): Promise<void> {
     await this.model.updateOne({ _id: id }, { $set: data })
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.model.deleteOne({ _id: id })
   }
 
   async findBySubjectAndDate(subjectId: string, date: Date): Promise<ClassLesson | null> {

--- a/backend/src/repositories/ClassLessons/IClassLessonsRepository.ts
+++ b/backend/src/repositories/ClassLessons/IClassLessonsRepository.ts
@@ -2,12 +2,14 @@ import { ClassLesson } from '../../entities/classLesson'
 
 export interface INewClassLessonDTO {
   subjectId: string
-  date: Date
+  date?: Date
+  description?: string
 }
 
 export interface IClassLessonsRepository {
   create(data: INewClassLessonDTO): Promise<ClassLesson>
   findBySubjectAndDate(subjectId: string, date: Date): Promise<ClassLesson | null>
   listAll(): Promise<ClassLesson[]>
-  update(id: string, data: Partial<INewClassLessonDTO & { description?: string }>): Promise<void>
+  update(id: string, data: Partial<INewClassLessonDTO>): Promise<void>
+  delete(id: string): Promise<void>
 }

--- a/backend/src/shared/infra/http/routes/classLessons.ts
+++ b/backend/src/shared/infra/http/routes/classLessons.ts
@@ -9,5 +9,6 @@ classLessonRoutes.use(ensureAuthenticated)
 classLessonRoutes.post('/', classLessonController.create)
 classLessonRoutes.get('/', classLessonController.list)
 classLessonRoutes.put('/:id', classLessonController.update)
+classLessonRoutes.delete('/:id', classLessonController.delete)
 
 export { classLessonRoutes }

--- a/backend/src/useCases/Attendance/ListAttendances/ListAttendancesService.service.ts
+++ b/backend/src/useCases/Attendance/ListAttendances/ListAttendancesService.service.ts
@@ -14,6 +14,7 @@ export class ListAttendancesService {
       _id: att._id,
       date: att.date,
       subject: (att.subject as any)?.name || '',
+      subjectId: (att.subject as any)?._id?.toString() || '',
     }))
   }
 }

--- a/backend/src/useCases/ClassLesson/CreateClassLesson/CreateClassLessonService.service.ts
+++ b/backend/src/useCases/ClassLesson/CreateClassLesson/CreateClassLessonService.service.ts
@@ -2,12 +2,10 @@ import { inject, injectable } from 'tsyringe'
 import { IClassLessonsRepository, INewClassLessonDTO } from '../../../repositories/ClassLessons/IClassLessonsRepository'
 import { ISubjectsRepository } from '../../../repositories/Subjects/ISubjectsRepository'
 import { IUsersRepository } from '../../../repositories/Users/IUsersRepository'
-import bcrypt from 'bcrypt'
 import { AppError } from '../../../shared/errors/AppError'
 
 interface IRequest extends INewClassLessonDTO {
   teacherId: string
-  teacherPassword: string
 }
 
 @injectable()
@@ -26,17 +24,14 @@ export class CreateClassLessonService {
     this.usersRepository = usersRepository
   }
 
-  async execute({ subjectId, date, teacherId, teacherPassword }: IRequest) {
-    const teacher = await this.usersRepository.findByIdWithPassword(teacherId)
+  async execute({ subjectId, teacherId, date, description }: IRequest) {
+    const teacher = await this.usersRepository.findById(teacherId)
     if (!teacher) throw new AppError('Professor não encontrado')
-
-    const passwordMatch = await bcrypt.compare(teacherPassword, teacher.password)
-    if (!passwordMatch) throw new AppError('Senha incorreta')
 
     const subject = await this.subjectsRepository.findById(subjectId)
     if (!subject || subject.teacher.toString() !== teacherId)
       throw new AppError('Disciplina inválida')
 
-    await this.classLessonsRepository.create({ subjectId, date })
+    await this.classLessonsRepository.create({ subjectId, date, description })
   }
 }

--- a/backend/src/useCases/ClassLesson/DeleteClassLesson/DeleteClassLessonService.service.ts
+++ b/backend/src/useCases/ClassLesson/DeleteClassLesson/DeleteClassLessonService.service.ts
@@ -2,21 +2,15 @@ import { inject, injectable } from 'tsyringe'
 import { IClassLessonsRepository } from '../../../repositories/ClassLessons/IClassLessonsRepository'
 import { AppError } from '../../../shared/errors/AppError'
 
-interface IRequest {
-  id: string
-  date: Date
-  description?: string
-  subjectId?: string
-}
-
 @injectable()
-export class UpdateClassLessonService {
+export class DeleteClassLessonService {
   constructor(
     @inject('ClassLessonsRepository') private classLessonsRepository: IClassLessonsRepository,
   ) {}
 
-  async execute({ id, date, description, subjectId }: IRequest): Promise<void> {
+  async execute(id: string): Promise<void> {
     if (!id) throw new AppError('Id da aula não informado')
-    await this.classLessonsRepository.update(id, { date, description, subjectId })
+
+    await this.classLessonsRepository.delete(id)
   }
 }

--- a/backend/src/useCases/ClassLesson/ListClassLessons/ListClassLessonsService.service.ts
+++ b/backend/src/useCases/ClassLesson/ListClassLessons/ListClassLessonsService.service.ts
@@ -14,6 +14,7 @@ export class ListClassLessonsService {
       date: lesson.date,
       description: lesson.description,
       subject: (lesson.subject as any)?.name || '',
+      subjectId: (lesson.subject as any)?._id?.toString() || '',
     }))
   }
 }

--- a/frontend/src/screens/Student/Absences/index.tsx
+++ b/frontend/src/screens/Student/Absences/index.tsx
@@ -16,30 +16,34 @@ interface Row {
 
 export function StudentAbsences() {
   const [rows, setRows] = useState<Row[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const user = usersService.getUserInfo()
     if (user?._id) {
+      setLoading(true)
       Promise.all([
         classLessonsService.getAll(),
         attendancesService.listByStudent(user._id),
-      ]).then(([lessRes, attRes]) => {
-        const lessons = lessRes.data.items || []
-        const attendances = attRes.data.items || []
-        const formatted = lessons.map((l: any) => {
-          const present = attendances.some((a: any) =>
-            dayjs(a.date).isSame(l.date, 'day'),
-          )
-          return {
-            _id: l._id,
-            date: dayjs(l.date).format('DD/MM/YYYY'),
-            subject: l.subject,
-            description: l.description,
-            status: present ? 'Presente' : 'Ausente',
-          }
+      ])
+        .then(([lessRes, attRes]) => {
+          const lessons = lessRes.data.items || []
+          const attendances = attRes.data.items || []
+          const formatted = lessons.map((l: any) => {
+            const present = attendances.some((a: any) =>
+              dayjs(a.date).isSame(l.date, 'day'),
+            )
+            return {
+              _id: l._id,
+              date: dayjs(l.date).format('DD/MM/YYYY'),
+              subject: l.subject,
+              description: l.description,
+              status: present ? 'Presente' : 'Ausente',
+            }
+          })
+          setRows(formatted)
         })
-        setRows(formatted)
-      })
+        .finally(() => setLoading(false))
     }
   }, [])
 
@@ -55,5 +59,5 @@ export function StudentAbsences() {
     },
   ]
 
-  return <TableComponent rows={rows} columns={columns} loading={false} />
+  return <TableComponent rows={rows} columns={columns} loading={loading} />
 }

--- a/frontend/src/screens/Teacher/StudentsAbsences/ModalClassLessonsList/ModalClassLessonsList.module.scss
+++ b/frontend/src/screens/Teacher/StudentsAbsences/ModalClassLessonsList/ModalClassLessonsList.module.scss
@@ -1,39 +1,49 @@
 @import "../../../../../styles/colors.scss";
 
-.list {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.table {
+  width: 100%;
+  border-collapse: collapse;
 
-  .item {
+  th,
+  td {
+    padding: 0.5rem;
+    text-align: left;
+  }
+
+  thead {
     background: $gray-color-100;
-    color: $gray-color-400;
-    padding: 0.6rem;
-    border-radius: 10px;
-    box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.1);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
   }
 
-  .editRow {
-    display: flex;
-    gap: 10px;
+  tbody tr:nth-child(even) {
+    background: $gray-color-100;
   }
+}
 
-  .editBtn {
-    background: $blue-color-500;
-    border: none;
-    color: $white-color;
-    padding: 4px 8px;
-    border-radius: 4px;
-    cursor: pointer;
-  }
+.item {
+  color: $gray-color-400;
+}
 
-  .saveBtn {
-    @extend .editBtn;
-    background: $primary-color;
-  }
+.editRow {
+  display: flex;
+  gap: 10px;
+}
+
+.editBtn {
+  background: $blue-color-500;
+  border: none;
+  color: $white-color;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.saveBtn {
+  @extend .editBtn;
+  background: $primary-color;
+}
+
+.deleteBtn {
+  @extend .editBtn;
+  background: $red-color-500;
+  margin-left: 5px;
 }

--- a/frontend/src/screens/Teacher/StudentsAbsences/ModalClassLessonsList/index.tsx
+++ b/frontend/src/screens/Teacher/StudentsAbsences/ModalClassLessonsList/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import dayjs from 'dayjs'
 import { ModalLayout } from '../../../../components/ModalLayout'
 import { classLessonsService } from '../../../../services/classLessonsService'
+import { subjectsService } from '../../../../services/subjectsService'
 import style from './ModalClassLessonsList.module.scss'
 import { Loading } from '../../../../components/Loading'
 import { EmptyItems } from '../../../../components/EmptyItems'
@@ -20,9 +21,12 @@ interface Props {
 
 export function ModalClassLessonsList({ open, handleClose }: Props) {
   const [lessons, setLessons] = useState<Lesson[]>([])
+  const [subjects, setSubjects] = useState<any[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const [editLessonId, setEditLessonId] = useState<string>('')
   const [newDate, setNewDate] = useState<string>('')
+  const [newSubject, setNewSubject] = useState<string>('')
+  const [newDescription, setNewDescription] = useState<string>('')
 
   function fetchLessons() {
     setLoading(true)
@@ -31,6 +35,7 @@ export function ModalClassLessonsList({ open, handleClose }: Props) {
       .then((res) => setLessons(res.data.items))
       .catch(() => {})
       .finally(() => setLoading(false))
+    subjectsService.getAll().then((res) => setSubjects(res.data.items || []))
   }
 
   useEffect(() => {
@@ -42,46 +47,93 @@ export function ModalClassLessonsList({ open, handleClose }: Props) {
   function handleEdit(lesson: Lesson) {
     setEditLessonId(lesson._id)
     setNewDate(dayjs(lesson.date).format('YYYY-MM-DDTHH:mm'))
+    setNewSubject((lesson as any).subjectId || '')
+    setNewDescription(lesson.description || '')
   }
 
   function handleSave() {
     classLessonsService
-      .update({ id: editLessonId, date: newDate })
+      .update({ id: editLessonId, date: newDate, subjectId: newSubject, description: newDescription })
       .then(fetchLessons)
       .finally(() => setEditLessonId(''))
+  }
+
+  function handleDelete(id: string) {
+    classLessonsService.delete(id).then(fetchLessons)
   }
 
   return (
     <ModalLayout open={open} handleClose={handleClose} title="Aulas cadastradas">
       {loading && <Loading size={25} color="#cd1414" />}
       {!loading && (
-        <ul className={style.list}>
-          {lessons.map((lesson) => (
-            <li key={lesson._id} className={style.item}>
-              {editLessonId === lesson._id ? (
-                <div className={style.editRow}>
-                  <input
-                    type="datetime-local"
-                    value={newDate}
-                    onChange={(e) => setNewDate(e.target.value)}
-                  />
-                  <button type="button" onClick={handleSave} className={style.saveBtn}>
-                    Salvar
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <span>{dayjs(lesson.date).format('DD/MM/YYYY HH:mm')}</span>
-                  <span>{lesson.subject}</span>
-                  <button type="button" onClick={() => handleEdit(lesson)} className={style.editBtn}>
-                    Editar
-                  </button>
-                </>
-              )}
-            </li>
-          ))}
-          {lessons.length === 0 && <EmptyItems text="Nenhuma aula cadastrada" customStyle={{ boxShadow: 'none' }}/>} 
-        </ul>
+        <table className={style.table}>
+          <thead>
+            <tr>
+              <th>Data</th>
+              <th>Disciplina</th>
+              <th>Descrição</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lessons.map((lesson) => (
+              <tr key={lesson._id} className={style.item}>
+                {editLessonId === lesson._id ? (
+                  <>
+                    <td>
+                      <input
+                        type="datetime-local"
+                        value={newDate}
+                        onChange={(e) => setNewDate(e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <select value={newSubject} onChange={(e) => setNewSubject(e.target.value)}>
+                        <option value="">Selecione</option>
+                        {subjects.map((s) => (
+                          <option key={s._id} value={s._id}>
+                            {s.name}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td>
+                      <input
+                        type="text"
+                        value={newDescription}
+                        onChange={(e) => setNewDescription(e.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <button type="button" onClick={handleSave} className={style.saveBtn}>Salvar</button>
+                    </td>
+                  </>
+                ) : (
+                  <>
+                    <td>{dayjs(lesson.date).format('DD/MM/YYYY HH:mm')}</td>
+                    <td>{lesson.subject}</td>
+                    <td>{lesson.description || '--'}</td>
+                    <td>
+                      <button type="button" onClick={() => handleEdit(lesson)} className={style.editBtn}>
+                        Editar
+                      </button>
+                      <button type="button" onClick={() => handleDelete(lesson._id)} className={style.deleteBtn}>
+                        Deletar
+                      </button>
+                    </td>
+                  </>
+                )}
+              </tr>
+            ))}
+            {lessons.length === 0 && (
+              <tr>
+                <td colSpan={4}>
+                  <EmptyItems text="Nenhuma aula cadastrada" customStyle={{ boxShadow: 'none' }} />
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       )}
     </ModalLayout>
   )

--- a/frontend/src/screens/Teacher/StudentsAbsences/ModalCreateClassLesson/index.tsx
+++ b/frontend/src/screens/Teacher/StudentsAbsences/ModalCreateClassLesson/index.tsx
@@ -15,8 +15,7 @@ export function ModalCreateClassLesson({ open, handleClose }: Props) {
   const { alertNotifyConfigs, setAlertNotifyConfigs } = useContext(AlertContext)
   const [subjectId, setSubjectId] = useState('')
   const [subjects, setSubjects] = useState<any[]>([])
-  const [date, setDate] = useState('')
-  const [password, setPassword] = useState('')
+  const [description, setDescription] = useState('')
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
@@ -31,7 +30,7 @@ export function ModalCreateClassLesson({ open, handleClose }: Props) {
     event.preventDefault()
     setLoading(true)
     classLessonsService
-      .create({ subjectId, date: new Date(date), teacherPassword: password })
+      .create({ subjectId, description })
       .then(() => {
         setAlertNotifyConfigs({
           ...alertNotifyConfigs,
@@ -78,16 +77,9 @@ export function ModalCreateClassLesson({ open, handleClose }: Props) {
         </Select>
       </FormControl>
       <CustomTextField
-        label="Data"
-        type="datetime-local"
-        value={date}
-        onChange={(e) => setDate(e.target.value)}
-      />
-      <CustomTextField
-        label="Senha"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
+        label="Descrição"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
       />
     </ModalLayout>
   )

--- a/frontend/src/screens/Teacher/StudentsAbsences/hooks/useColumns.tsx
+++ b/frontend/src/screens/Teacher/StudentsAbsences/hooks/useColumns.tsx
@@ -36,7 +36,7 @@ export function useColumns({ attendancePercentages, onViewAttendances }: Params)
           className={style.buttonView}
           onClick={() => onViewAttendances(params.data)}
         >
-          <FontAwesomeIcon icon={faEye} />
+          <FontAwesomeIcon icon={faEye} /> Ver presenças
         </button>
       ),
     },

--- a/frontend/src/services/classLessonsService.ts
+++ b/frontend/src/services/classLessonsService.ts
@@ -1,8 +1,8 @@
 import http from '../api/http'
 
 export const classLessonsService = {
-  create({ subjectId, date, teacherPassword }: any) {
-    const body = { subjectId, date, teacherPassword }
+  create({ subjectId, description }: any) {
+    const body = { subjectId, description }
     return http.post('/classLessons', body)
   },
 
@@ -10,7 +10,11 @@ export const classLessonsService = {
     return http.get('/classLessons')
   },
 
-  update({ id, date, description }: any) {
-    return http.put(`/classLessons/${id}`, { date, description })
+  update({ id, date, description, subjectId }: any) {
+    return http.put(`/classLessons/${id}`, { date, description, subjectId })
+  },
+
+  delete(id: string) {
+    return http.delete(`/classLessons/${id}`)
   },
 }


### PR DESCRIPTION
## Summary
- improve class lesson backend: allow description, remove password requirement, add delete functionality
- expose subjectId on lesson and attendance APIs
- handle delete/update in classLessons service
- update teacher absences UI and logic
- show lesson description when creating
- improve lessons list modal with edit/delete options
- fix student absences table loading

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865aecaf4708322aaf322ca725db841