### PR TITLE
Fix class lesson date handling

### DIFF
--- a/backend/src/controllers/ClassLessonController.ts
+++ b/backend/src/controllers/ClassLessonController.ts
@@ -7,10 +7,10 @@ import { DeleteClassLessonService } from '../useCases/ClassLesson/DeleteClassLes
 
 export class ClassLessonController {
   async create(req: Request, res: Response): Promise<Response> {
-    const { subjectId, description } = req.body
+    const { subjectId, description, date } = req.body
     const { _id: teacherId } = req.user
     const service = container.resolve(CreateClassLessonService)
-    await service.execute({ subjectId, teacherId, description })
+    await service.execute({ subjectId, teacherId, description, date })
     return res.status(201).json({ success: true })
   }
 


### PR DESCRIPTION
## Summary
- ensure class lesson creation passes the selected `date` instead of using today's default

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bceeb5f883228206e41b6a0a82a2