### PR TITLE
Fix class lesson date handling

### DIFF
--- a/backend/src/controllers/ClassLessonController.ts
+++ b/backend/src/controllers/ClassLessonController.ts
@@ -7,10 +7,10 @@ import { DeleteClassLessonService } from '../useCases/ClassLesson/DeleteClassLes
 
 export class ClassLessonController {
   async create(req: Request, res: Response): Promise<Response> {
-    const { subjectId, description } = req.body
+    const { subjectId, description, date } = req.body
     const { _id: teacherId } = req.user
     const service = container.resolve(CreateClassLessonService)
-    await service.execute({ subjectId, teacherId, description })
+    await service.execute({ subjectId, teacherId, description, date })
     return res.status(201).json({ success: true })
   }
 
@@ -22,9 +22,9 @@ export class ClassLessonController {
 
   async update(req: Request, res: Response): Promise<Response> {
     const { id } = req.params
-    const { date, description } = req.body
+    const { date, description, subjectId } = req.body
     const service = container.resolve(UpdateClassLessonService)
-    await service.execute({ id, date, description })
+    await service.execute({ id, date, description, subjectId })
     return res.status(200).json({ success: true })
   }
 

--- a/backend/src/useCases/Attendance/CreateAttendance/CreateAttendanceService.service.ts
+++ b/backend/src/useCases/Attendance/CreateAttendance/CreateAttendanceService.service.ts
@@ -34,6 +34,7 @@ export class CreateAttendanceService {
     code,
     password,
   }: INewAttendanceDTO): Promise<void> {
+    const normalizedDate = new Date(date)
     let student = null
     if (studentId) {
       student = await this.usersRepository.findByIdWithPassword(studentId)
@@ -59,14 +60,24 @@ export class CreateAttendanceService {
     if (!passwordMatch) throw new AppError('Código ou senha incorreto')
 
     const attendanceExists =
-      await this.attendancesRepository.findByStudentAndDate(resolvedStudentId, date)
+      await this.attendancesRepository.findByStudentAndDate(
+        resolvedStudentId,
+        normalizedDate,
+      )
 
-    const hasClass = await this.classLessonsRepository.findBySubjectAndDate(subjectId, date)
+    const hasClass = await this.classLessonsRepository.findBySubjectAndDate(
+      subjectId,
+      normalizedDate,
+    )
     if (!hasClass) throw new AppError('Nenhuma aula cadastrada para esta data')
 
     if (attendanceExists)
       throw new AppError('Presença deste dia já registrada')
 
-    await this.attendancesRepository.create({ studentId: resolvedStudentId, date, subjectId })
+    await this.attendancesRepository.create({
+      studentId: resolvedStudentId,
+      date: normalizedDate,
+      subjectId,
+    })
   }
 }

--- a/backend/src/useCases/ClassLesson/UpdateClassLesson/UpdateClassLessonService.service.ts
+++ b/backend/src/useCases/ClassLesson/UpdateClassLesson/UpdateClassLessonService.service.ts
@@ -1,10 +1,13 @@
 import { inject, injectable } from 'tsyringe'
-import { IClassLessonsRepository } from '../../../repositories/ClassLessons/IClassLessonsRepository'
+import {
+  IClassLessonsRepository,
+  INewClassLessonDTO,
+} from '../../../repositories/ClassLessons/IClassLessonsRepository'
 import { AppError } from '../../../shared/errors/AppError'
 
 interface IRequest {
   id: string
-  date: Date
+  date?: string | Date
   description?: string
   subjectId?: string
 }
@@ -17,6 +20,13 @@ export class UpdateClassLessonService {
 
   async execute({ id, date, description, subjectId }: IRequest): Promise<void> {
     if (!id) throw new AppError('Id da aula não informado')
-    await this.classLessonsRepository.update(id, { date, description, subjectId })
+
+    const updateData: Partial<INewClassLessonDTO> = {}
+
+    if (date) updateData.date = new Date(date)
+    if (description !== undefined) updateData.description = description
+    if (subjectId) updateData.subjectId = subjectId
+
+    await this.classLessonsRepository.update(id, updateData)
   }
 }


### PR DESCRIPTION
## Summary
- ensure class lesson creation passes the selected `date` instead of using today's default
- allow lesson update to modify date/subject
- normalize date when marking attendance

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bceeb5f883228206e41b6a0a82a2